### PR TITLE
chore(act): automatic lockfile updates

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: "0 0 * * *" # runs daily at 00:00
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          pr-title: "build(lock): update"
+          pr-labels: |
+            lock
+          pr-assignees: youwen5


### PR DESCRIPTION
Adds [Determinate Systems action](https://github.com/DeterminateSystems/update-flake-lock) for automatic lockfile updates. Follow [these instructions](https://github.com/DeterminateSystems/update-flake-lock#with-a-personal-authentication-token) to create the relevant secret necessary to run CI on auto-generated PRs.

This PR imports the latest and greatest [QuasarOS](https://github.com/quantum9Innovation/QuasarOS) technology to maximize automation. Code may be subject to [export control restrictions](https://www.trade.gov/us-export-controls) for national security reasons. This PR is the first of many intended to correct a current trade deficit that QuasarOS runs with LiminalOS.