### PR TITLE
feat: enable auto update system service

### DIFF
--- a/reference/hosts/adrastea/configuration.nix
+++ b/reference/hosts/adrastea/configuration.nix
@@ -8,7 +8,7 @@
   lib,
   ...
 }:
-{
+rec {
   imports = [ ./hardware-configuration.nix ];
 
   networking.hostName = "adrastea";
@@ -92,12 +92,24 @@
 
   nixpkgs.config.allowUnfree = true;
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It‘s perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05"; # Did you read the comment?
+  system = {
+    # This value determines the NixOS release from which the default
+    # settings for stateful data, like file locations and database versions
+    # on your system were taken. It‘s perfectly fine and recommended to leave
+    # this value at the release version of the first install of this system.
+    # Before changing this value read the documentation for this option
+    # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+    stateVersion = "24.05"; # Did you read the comment?
+    
+    # Automatically rebuild system daily
+    autoUpgrade = {
+      enable = true;
+      flake = liminalOS.flakeLocation;
+      flags = [
+        "-L" # print build logs
+      ];
+      dates = "daily";
+    };
+  };
 
 }

--- a/reference/hosts/callisto/configuration.nix
+++ b/reference/hosts/callisto/configuration.nix
@@ -7,7 +7,7 @@
   lib,
   ...
 }:
-{
+rec {
   imports = [ ./hardware-configuration.nix ];
 
   networking.hostName = "callisto";
@@ -74,5 +74,17 @@
     };
   };
 
-  system.stateVersion = "24.11";
+  system = {
+    stateVersion = "24.11";
+    
+    # Automatically rebuild system daily
+    autoUpgrade = {
+      enable = true;
+      flake = liminalOS.flakeLocation;
+      flags = [
+        "-L" # print build logs
+      ];
+      dates = "daily";
+    };
+  };
 }

--- a/reference/hosts/cassini/configuration.nix
+++ b/reference/hosts/cassini/configuration.nix
@@ -6,7 +6,7 @@
   inputs,
   ...
 }:
-{
+rec {
   networking.hostName = "cassini"; # Define your hostname.
 
   liminalOS = {
@@ -43,11 +43,23 @@
 
   nixpkgs.hostPlatform = "x86_64-linux";
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It‘s perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05"; # Did you read the comment?
+  system = {
+    # This value determines the NixOS release from which the default
+    # settings for stateful data, like file locations and database versions
+    # on your system were taken. It‘s perfectly fine and recommended to leave
+    # this value at the release version of the first install of this system.
+    # Before changing this value read the documentation for this option
+    # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+    stateVersion = "24.05"; # Did you read the comment?
+    
+    # Automatically rebuild system daily
+    autoUpgrade = {
+      enable = true;
+      flake = liminalOS.flakeLocation;
+      flags = [
+        "-L" # print build logs
+      ];
+      dates = "daily";
+    };
+  };
 }

--- a/reference/hosts/demeter/configuration.nix
+++ b/reference/hosts/demeter/configuration.nix
@@ -6,7 +6,7 @@
   pkgs,
   ...
 }:
-{
+rec {
   imports = [
     ./hardware-configuration.nix
   ];
@@ -67,11 +67,23 @@
       "/dev/disk/by-uuid/af320a0f-b388-43f5-b5a3-af2b47cfc716";
   };
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It‘s perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05"; # Did you read the comment?
+  system = {
+    # This value determines the NixOS release from which the default
+    # settings for stateful data, like file locations and database versions
+    # on your system were taken. It‘s perfectly fine and recommended to leave
+    # this value at the release version of the first install of this system.
+    # Before changing this value read the documentation for this option
+    # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+    stateVersion = "24.05"; # Did you read the comment?
+    
+    # Automatically rebuild system daily
+    autoUpgrade = {
+      enable = true;
+      flake = liminalOS.flakeLocation;
+      flags = [
+        "-L" # print build logs
+      ];
+      dates = "daily";
+    };
+  };
 }

--- a/reference/modules/default.nix
+++ b/reference/modules/default.nix
@@ -66,6 +66,22 @@
         ExecStart = "/nix/var/nix/profiles/system/bin/switch-to-configuration test";
       };
     };
+    refresh = let 
+      flakeLocation = "/home/youwen/.config/liminalOS";
+    in {
+      description = "Automatically update liminalOS";
+      after = [ "network-online.target" ];
+      requires = [ "network-online.target" ];
+      script = ''
+        cd ${flakeLocation}
+        ${pkgs.git}/bin/git config --global --add safe.directory ${flakeLocation}
+        ${pkgs.git}/bin/git pull
+      '';
+      serviceConfig = {
+        Environment = "HOME=/root";
+      };
+      wantedBy = [ ];
+    };
   };
   systemd.timers = {
     colorscheme-dawn = {
@@ -84,6 +100,15 @@
         OnCalendar = "*-*-* 18:00:00";
         Persistent = true;
         Unit = "colorscheme-dusk.service";
+      };
+    };
+    refresh = {
+      description = "Schedule daily system updates";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+        Unit = "refresh.service";
       };
     };
   };

--- a/templates/minimal/configuration.nix
+++ b/templates/minimal/configuration.nix
@@ -6,7 +6,7 @@
   inputs,
   ...
 }:
-{
+rec {
   imports = [
     # Important: you should replace hardware-configuration.nix with your actual
     # hardware-configuration.nix generated during NixOS installation, located
@@ -95,11 +95,23 @@
     };
   };
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It‘s perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05"; # Did you read the comment?
+  system = {
+    # This value determines the NixOS release from which the default
+    # settings for stateful data, like file locations and database versions
+    # on your system were taken. It‘s perfectly fine and recommended to leave
+    # this value at the release version of the first install of this system.
+    # Before changing this value read the documentation for this option
+    # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+    stateVersion = "24.05"; # Did you read the comment?
+    
+    # Automatically rebuild system daily
+    autoUpgrade = {
+      enable = true;
+      flake = liminalOS.flakeLocation;
+      flags = [
+        "-L" # print build logs
+      ];
+      dates = "daily";
+    };
+  };
 }


### PR DESCRIPTION
Defines a system service that automatically pulls new sources from the liminalOS source repo daily, assuming lockfile updates are automatically configured, and then configures the built-in Nix configuration option for automatic daily system rebuilds.

This PR was brought to you by experimental research being conducted at [QuasarOS](https://github.com/quantum9Innovation/QuasarOS/pull/56) as part of our efforts to assist underdeveloped systems. These systems have been cleared for shipment out of Massachusetts research facilities and to the shores of the Pacific, headquarters of liminalOS, per the interstate commerce clause.